### PR TITLE
feat: Added `get` and `__getitem__` and `__setitem__`

### DIFF
--- a/optopenhash/elastic_hashing.py
+++ b/optopenhash/elastic_hashing.py
@@ -32,6 +32,9 @@ class ElasticHashTable:
         # Returns the index for the j-th quadratic probe.
         return (self._hash(key, level) + j * j) % table_size
 
+    def __setitem__(self, key, value):
+        self.insert(key, value)
+
     def insert(self, key, value):
         if self.num_inserts >= self.max_inserts:
             raise RuntimeError(
@@ -86,6 +89,15 @@ class ElasticHashTable:
                         self.num_inserts += 1
                         return True
         raise RuntimeError("Insertion failed in all levels; hash table is full.")
+
+    def __getitem__(self, key):
+        ret = self.search(key)
+        if ret is None:
+            raise KeyError(key)
+        return ret
+
+    def get(self, key, default=None):
+        return self.search(key) or default
 
     def search(self, key):
         for i, level in enumerate(self.levels):

--- a/optopenhash/funnel_hashing.py
+++ b/optopenhash/funnel_hashing.py
@@ -57,6 +57,9 @@ class FunnelHashTable:
     def _hash_special(self, key):
         return hash((key, self.special_salt)) & 0x7FFFFFFF
 
+    def __setitem__(self, key, value):
+        self.insert(key, value)
+
     def insert(self, key, value):
         if self.num_inserts >= self.max_inserts:
             raise RuntimeError(
@@ -103,6 +106,15 @@ class FunnelHashTable:
             return True
         else:
             raise RuntimeError("Special array insertion failed; table is full.")
+
+    def __getitem__(self, key):
+        ret = self.search(key)
+        if ret is None:
+            raise KeyError(key)
+        return ret
+
+    def get(self, key, default=None):
+        return self.search(key) or default
 
     def search(self, key):
         for i in range(len(self.levels)):


### PR DESCRIPTION
Added `get` and `__getitem__` and `__setitem__` to make their APIs closer to dict for easier comparisons under the same syntax.

test code:
```py
from optopenhash import ElasticHashTable, FunnelHashTable

# Create a table with capacity 1000 and delta = 0.1 (so up to 900 insertions)
etable = ElasticHashTable(capacity=1000, delta=0.1)
fhtable = FunnelHashTable(capacity=1000, delta=0.1)

# Insert some key-value pairs
for i in range(800):
    etable[f"key{i}"] = f"value{i}"
    fhtable[f"key{i}"] = f"value{i}"

# Search for a key
print(etable[f"key{123}"])
print(fhtable[f"key{456}"])

```